### PR TITLE
Implement operator== and hashCode for Rect.

### DIFF
--- a/lib/src/rect.dart
+++ b/lib/src/rect.dart
@@ -210,7 +210,19 @@ class Rect extends IterableBase<Vec> {
     return const <Vec>[];
   }
 
-  // TODO: Equality operator and hashCode.
+  bool operator==(o) {
+    if (o is! Rect) {
+      return false;
+    }
+    return pos == o.pos && size == o.size;
+  }
+
+  int get hashCode {
+    int posHash = pos.hashCode;
+    int sizeHash = size.hashCode;
+    return ((posHash + sizeHash) << 6) ^ ((posHash + sizeHash) >> 2);
+  }
+
 }
 
 class RectIterator implements Iterator<Vec> {

--- a/test/rect_test.dart
+++ b/test/rect_test.dart
@@ -102,6 +102,13 @@ void main() {
     expect(new Rect(1, 2, 3, 4).toString(), equals("(1, 2)-(3, 4)"));
   });
 
+  test("==", () {
+    expect(new Rect(1, 2, 3, 4) == new Rect(1, 2, 3, 4), isTrue);
+    expect(new Rect(1, 2, 3, 4) == new Rect(2, 1, 3, 4), isFalse);
+
+    expect(new Rect(1, 1, 1, 1) == new Vec(0, 1), isFalse);
+  });
+
   // TODO: intersect().
   // TODO: centerIn().
   // TODO: center.


### PR DESCRIPTION
I've implemented equality and hashCode operations for Rect. I wasn't sure if it was better to compare based on top/left/bottom/right, or pos/size, but went with pos/size because those are externally visible (It would be pretty crappy for `r1 == r2` to be true but `r1.x == r2.x` not to be).

The downside of this is that now two Rects might contain an identical set of points (err, Vecs), but not compare as equal.

I have tests for the operator== but not for the hashCode because I'm not sure it would make sense to test hashCode.
